### PR TITLE
Fix validation rule callback typing

### DIFF
--- a/src/Http/Psr15GraphQLMiddlewareBuilder.php
+++ b/src/Http/Psr15GraphQLMiddlewareBuilder.php
@@ -6,6 +6,8 @@ namespace TheCodingMachine\GraphQLite\Http;
 
 use DateInterval;
 use GraphQL\Error\DebugFlag;
+use GraphQL\Language\AST\DocumentNode;
+use GraphQL\Server\OperationParams;
 use GraphQL\Server\ServerConfig;
 use GraphQL\Type\Schema;
 use GraphQL\Validator\DocumentValidator;
@@ -133,13 +135,17 @@ class Psr15GraphQLMiddlewareBuilder
         // So if we only added given rule, all of the default rules would not be validated, so we must also provide them.
         $originalValidationRules = $this->config->getValidationRules() ?? DocumentValidator::allRules();
 
-        $this->config->setValidationRules(function (...$args) use ($originalValidationRules) {
-            if (is_callable($originalValidationRules)) {
-                $originalValidationRules = $originalValidationRules(...$args);
-            }
+        $this->config->setValidationRules(function (
+            OperationParams $operation,
+            DocumentNode $doc,
+            string $operationType,
+        ) use ($originalValidationRules): array {
+            $validationRules = is_callable($originalValidationRules)
+                ? $originalValidationRules($operation, $doc, $operationType)
+                : $originalValidationRules;
 
             return [
-                ...$originalValidationRules,
+                ...$validationRules,
                 ...$this->addedValidationRules,
             ];
         });


### PR DESCRIPTION
### Motivation
- PHPStan reported a type mismatch for the validation-rules callback because the callable must accept `OperationParams` and `DocumentNode` but the code used an untyped variadic forwarding signature.
- The change aims to provide an explicitly-typed callback so static analysis can validate the Webonyx `setValidationRules` callback signature while preserving existing runtime behavior.

### Description
- Import `GraphQL\Server\OperationParams` and `GraphQL\Language\AST\DocumentNode` and use them in the callback signature.
- Replace the variadic `function (...$args)` forwarding with a typed callback: `function (OperationParams $operation, DocumentNode $doc, string $operationType): array`.
- When `getValidationRules()` is callable, call it using the typed parameters; otherwise treat it as the rules array, then merge with the builder's added rules and return the combined array.
- Keep the returned type as `array` and preserve support for both callable and array validation-rule configurations.

### Testing
- Ran `php -l src/Http/Psr15GraphQLMiddlewareBuilder.php` which succeeded.
- Ran `git diff --check` which reported no problems.
- Ran `composer install --no-interaction --no-progress` which failed due to Packagist/network restriction (CONNECT tunnel 403).
- Ran `composer phpstan` and `composer test` which failed because dev tooling binaries (`phpstan`, `phpcs`) are not available in the environment (dependencies not installed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27fd191ef083278befdd901416213f)